### PR TITLE
Make clusters clickable hurricane-response/response-theme#22

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -12,7 +12,7 @@
 	>
 		<div class="wrapper">
 			{% include header.html %}
-			
+
 			<main class="content">
             {% include txtbot.html %}
 			<div class="map-header">
@@ -23,7 +23,7 @@
     					<div id="map">
     					</div>
                         <div id='geocoder' class='geocoder'></div>
-    
+
 					</div>
 					<div class="map-legend">
     					<h3>Legend</h3>
@@ -50,7 +50,7 @@
 						</div>
 						 Shelter
 						</p>
-						</div>	
+						</div>
 					</div>
                     <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.3.0/mapbox-gl-geocoder.min.js'></script>
 <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.3.0/mapbox-gl-geocoder.css' type='text/css' />
@@ -61,7 +61,7 @@
 
     //TODO: move this to config.
     const MAP_LOAD_CENTER = [{{ site.shelter_map_center }}];
-    const ZOOM = [{{ site.shelter_zoom }}];
+    const INITIAL_ZOOM = [{{ site.shelter_zoom }}];
 
     var map = new mapboxgl.Map({
         // container id specified in the HTML
@@ -70,8 +70,7 @@
         style: 'mapbox://styles/miklb-c4tb/cjnozdzs41qlx2rqvf7mwfztt',
         // initial position in [lon, lat] format
         center: MAP_LOAD_CENTER,
-        // initial zoom
-        zoom: ZOOM
+        zoom: INITIAL_ZOOM
     });
 
 
@@ -128,6 +127,25 @@ map.on('load', function() {
             "text-size": 12
         }
     });
+
+    // on mouseover, make it obvious that clusters are interactive
+    map.on('mouseenter', 'clusters', () => {
+        map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', 'clusters', () => {
+        map.getCanvas().style.cursor = '';
+    });
+
+    map.on('click', 'clusters', e => {
+        const cluster = map.queryRenderedFeatures(e.point, { layers: ['clusters'] })[0];
+        const clusterId = cluster.properties.cluster_id;
+        const center = cluster.geometry.coordinates;
+        map.getSource('shelters').getClusterExpansionZoom(clusterId, (err, zoom) => {
+            err || map.easeTo({ center, zoom });
+        });
+    });
+
+
     map.loadImage("{{site.baseurl}}/assets/images/shelter-icon.png", (error, img) => {
         map.addImage("shelter", img);
         map.addLayer({
@@ -152,7 +170,7 @@ map.on('load', function() {
         map.on('mouseenter', 'unclustered-point', function () {
             map.getCanvas().style.cursor = 'pointer';
         });
-        
+
         // Change it back to a pointer when it leaves.
         map.on('mouseleave', 'unclustered-point', function () {
             map.getCanvas().style.cursor = '';

--- a/_layouts/pod.html
+++ b/_layouts/pod.html
@@ -12,7 +12,7 @@
 	>
 		<div class="wrapper">
 			{% include header.html %}
-			
+
 			<main class="content">
 			{% include txtbot.html %}
 			<div class="map-header">
@@ -22,7 +22,7 @@
 					<div id="map-container" class="shelter-map_container">
     					<div id="map">
     					</div>
-    
+
 					</div>
 					<div class="map-legend">
     					<h3>Legend</h3>
@@ -49,14 +49,14 @@
 						</div>
 						 Shelter
 						</p>
-						</div>	
+						</div>
 					</div>
 <script>
     // Load access token from config
     mapboxgl.accessToken = '{{site.mapbox_access_token}}';
 
     const MAP_LOAD_CENTER = [{{ site.pod_map_center }}];
-    const ZOOM = [{{ site.pod_zoom }}];
+    const INITIAL_ZOOM = [{{ site.pod_zoom }}];
 
     var map = new mapboxgl.Map({
         // container id specified in the HTML
@@ -65,8 +65,7 @@
         style: 'mapbox://styles/miklb-c4tb/cjnozdzs41qlx2rqvf7mwfztt',
         // initial position in [lon, lat] format
         center: MAP_LOAD_CENTER,
-        // initial zoom
-        zoom: ZOOM
+        zoom: INITIAL_ZOOM
     });
 map.on('load', function() {
     // Add a new source from our GeoJSON data and set the
@@ -110,6 +109,7 @@ map.on('load', function() {
             ]
         }
     });
+
     map.addLayer({
         id: "cluster-count",
         type: "symbol",
@@ -121,6 +121,26 @@ map.on('load', function() {
             "text-size": 14
         }
     });
+
+    // on mouseover, make it obvious that clusters are interactive
+    map.on('mouseenter', 'clusters', () => {
+        map.getCanvas().style.cursor = 'pointer';
+    });
+
+    // Change it back to a pointer when it leaves.
+    map.on('mouseleave', 'clusters', () => {
+        map.getCanvas().style.cursor = '';
+    });
+
+    map.on('click', 'clusters', e => {
+        const cluster = map.queryRenderedFeatures(e.point, { layers: ['clusters'] })[0];
+        const clusterId = cluster.properties.cluster_id;
+        const center = cluster.geometry.coordinates;
+        map.getSource('pods').getClusterExpansionZoom(clusterId, (err, zoom) => {
+            err || map.easeTo({ center, zoom });
+        });
+    });
+
     map.loadImage("{{site.baseurl}}/assets/images/shelter-icon.png", (error, img) => {
         map.addImage("shelter", img);
         map.addLayer({
@@ -145,7 +165,7 @@ map.on('load', function() {
         map.on('mouseenter', 'unclustered-point', function () {
             map.getCanvas().style.cursor = 'pointer';
         });
-        
+
         // Change it back to a pointer when it leaves.
         map.on('mouseleave', 'unclustered-point', function () {
             map.getCanvas().style.cursor = '';


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the CFA response theme. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #22 
<!-- Please describe your pull request. -->

Makes clusters clickable - both on the shelters page and the distribution points page. 
Code largely adapted from [mapbox cluster documentation](https://docs.mapbox.com/mapbox-gl-js/example/cluster/). Eventually, it would be nice to de-dupe code between those two layout pages. 

On click, recenters map on clicked cluster centroid and zooms until the cluster splits up (either into more clusters or individual points). 

Renamed `ZOOM` to `INITIAL_ZOOM` so it's obvious that variable is only used for initialization and doesn't store the state of the current zoom. Cleaned up some whitespace in the file. 


![c4a-hurricane](https://user-images.githubusercontent.com/10542153/66154900-5a752e80-e5d3-11e9-8eae-c5a88e5c1f9a.gif)


## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [x] I want my code added to the response theme.